### PR TITLE
Refactor pytest config: use `testpaths` instead of `norecursedirs`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -105,8 +105,7 @@ profile = "black"
 [tool.pytest.ini_options]
 addopts = "--verbose --color=yes --durations=10"
 asyncio_mode = "auto"
-# Ignore thousands of tests in dependencies installed in a virtual environment
-norecursedirs = "lib lib64"
+testpaths = ["tests"]
 
 
 # tbump is used to simplify and standardize the release process when updating


### PR DESCRIPTION
Min suggested the strategy of declaring what folders to inspect for Pytest over listing folders to ignore when scanning for tests.