### PR TITLE
Let RELEASE.md link out to practices on using github-activity

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -19,10 +19,10 @@ These are the instructions on how to make a release.
 ## Steps to make a release
 
 1. Create a PR updating `docs/source/changelog.md` with [github-activity] and
-   continue when its merged.
+   continue when its merged. For details about this, see the [team-compass
+   documentation] about it.
 
-   Advice on this procedure can be found in [this team compass
-   issue](https://github.com/jupyterhub/team-compass/issues/563).
+   [team-compass documentation]: https://jupyterhub-team-compass.readthedocs.io/en/latest/practices/releases.html
 
 2. Checkout main and make sure it is up to date.
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -19,33 +19,10 @@ These are the instructions on how to make a release.
 ## Steps to make a release
 
 1. Create a PR updating `docs/source/changelog.md` with [github-activity] and
-   continue to step 2 **only when its merged.**
+   continue when its merged.
 
-   Tips about getting the most out of github-activity (from https://github.com/jupyterhub/team-compass/issues/563):
-
-   - [ ] Run `github-activity --heading-level=3`
-   - [ ] Consider labelling PRs:
-     - Read the output of `github-activity` and look for PRs under the uncategorized heading
-       that didn't have a label for `github-activity` to sort it by.
-     - If any non-bot authored PRs are found there, visit them and add a relevant label.
-     - `github-activity` can't sort `ci` labels automatically to go under a `### Continuous integration` improvements heading,
-       so these need ot handeled manually.
-   - [ ] Cosider updating PR title:
-     - Read the output of `github-activity` and look for PRs with a title that can be improved,
-       then update the title of the PR on GitHub.
-   - [ ] Run `github-activity --heading-level=3` (again),
-         copy and paste the output of `github-activity` to the changelog and refine it manually:
-     - Decide a version increment.
-       - Bump major version if a breaking change is introduced
-         If a major version bump is made, also write some summary manually before listing all the PRs.
-       - Bump minor version if an enhancement or new feature is added
-       - Bump patch version if only documentation and bugfixes etc are provided.
-     - Add a date to the release that seems likely to match when it can get merged
-     - Remove various pre-commit PRs and dependabot PRs that just bumps CI stuff.
-     - Remove various @welcome, @dependabot, and other bots from contributors lists etc
-     - Put ci labelled PRs manually under `### Continuous integration` improvements heading
-   - [ ] Make a commit with a message similar to _"Add changelog for 1.2.3"_ and open a PR titled the same
-   - [ ] Await merge, then move on to step 2 described below
+   Advice on this procedure can be found in [this team compass
+   issue](https://github.com/jupyterhub/team-compass/issues/563).
 
 2. Checkout main and make sure it is up to date.
 


### PR DESCRIPTION
I want us to link to a central source of truth with regards to advice on how to make the changelog, as compared to inlining them in the individual project's RELEASE.md files. Like that, we can reduce the toil for updating things as details change.

As an example of change we can do in a single place instead of in each RELEASE.md going onwards, github-activity >0.3.0 will filter out a few bots we use in the contributor lists so we don't need to mention needing to do that.