### PR TITLE
RELEASE.md: reference github issue on advice developing over time

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -19,33 +19,10 @@ These are the instructions on how to make a release.
 ## Steps to make a release
 
 1. Create a PR updating `docs/source/changelog.md` with [github-activity] and
-   continue to step 2 **only when its merged.**
+   continue when its merged.
 
-   Tips about getting the most out of github-activity (from https://github.com/jupyterhub/team-compass/issues/563):
-
-   - [ ] Run `github-activity --heading-level=3`
-   - [ ] Consider labelling PRs:
-     - Read the output of `github-activity` and look for PRs under the uncategorized heading
-       that didn't have a label for `github-activity` to sort it by.
-     - If any non-bot authored PRs are found there, visit them and add a relevant label.
-     - `github-activity` can't sort `ci` labels automatically to go under a `### Continuous integration` improvements heading,
-       so these need ot handeled manually.
-   - [ ] Cosider updating PR title:
-     - Read the output of `github-activity` and look for PRs with a title that can be improved,
-       then update the title of the PR on GitHub.
-   - [ ] Run `github-activity --heading-level=3` (again),
-         copy and paste the output of `github-activity` to the changelog and refine it manually:
-     - Decide a version increment.
-       - Bump major version if a breaking change is introduced
-         If a major version bump is made, also write some summary manually before listing all the PRs.
-       - Bump minor version if an enhancement or new feature is added
-       - Bump patch version if only documentation and bugfixes etc are provided.
-     - Add a date to the release that seems likely to match when it can get merged
-     - Remove various pre-commit PRs and dependabot PRs that just bumps CI stuff.
-     - Remove various @welcome, @dependabot, and other bots from contributors lists etc
-     - Put ci labelled PRs manually under `### Continuous integration` improvements heading
-   - [ ] Make a commit with a message similar to _"Add changelog for 1.2.3"_ and open a PR titled the same
-   - [ ] Await merge, then move on to step 2 described below
+   Advice on this procedure can be found in [this team compass
+   issue](https://github.com/jupyterhub/team-compass/issues/563).
 
 2. Checkout main and make sure it is up to date.
 


### PR DESCRIPTION
This PR removes hardcoded advice on how to use github-activity by instead linking to the issue directly where it was taken from. Like this, we get a central source of truth. Maybe it would be cleaner to have that in official docs than a github issue, but I think this is a clear incremental improvement that is easier to migrate from.

As an example of how the advice can get outdated, soon/already we don't need to remove bot usernames manually for example which is part of the advice.

---

Ooops, already opened this PR last week. Closing this in favor of #21 which was exactly the same changes.