### PR TITLE
docs: remove redundant make config for linkcheck

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -30,11 +30,3 @@ help:
 # 
 devenv:
 	sphinx-autobuild -b html --open-browser "$(SOURCEDIR)" "$(BUILDDIR)/html" $(SPHINXOPTS)
-
-# For local development and CI:
-# - verifies that links are valid
-linkcheck:
-	$(SPHINXBUILD) -b linkcheck "$(SOURCEDIR)" "$(BUILDDIR)/linkcheck" $(SPHINXOPTS)
-	@echo
-	@echo "Link check complete; look for any errors in the above output " \
-	      "or in $(BUILDDIR)/linkcheck/output.txt."

--- a/docs/make.bat
+++ b/docs/make.bat
@@ -14,7 +14,6 @@ set BUILDDIR=_build
 
 if "%1" == "" goto help
 if "%1" == "devenv" goto devenv
-if "%1" == "linkcheck" goto linkcheck
 goto default
 
 
@@ -42,14 +41,6 @@ if errorlevel 9009 (
 	exit /b 1
 )
 sphinx-autobuild -b html --open-browser "%SOURCEDIR%" "%BUILDDIR%/html" %SPHINXOPTS%
-goto end
-
-
-:linkcheck
-%SPHINXBUILD% -b linkcheck "%SOURCEDIR%" "%BUILDDIR%/linkcheck" %SPHINXOPTS%
-echo.
-echo.Link check complete; look for any errors in the above output
-echo.or in "%BUILDDIR%/linkcheck/output.txt".
 goto end
 
 


### PR DESCRIPTION
This is a followup prompted by @GeorgianaElena's insight in https://github.com/jupyterhub/jupyterhub-python-repo-template/pull/8#pullrequestreview-1485680122